### PR TITLE
Add Next.js skeleton with Tic-Tac-Toe game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# deep-space-tic-tac-toe
+# Deep Space Tic-Tac-Toe
+
+This repository contains a minimal Next.js 15 project using React 19. It includes Tailwind CSS, basic setup for shadcn/ui components, and a simple Tic-Tac-Toe game with a scoreboard.
+
+## Getting Started
+
+Install dependencies (requires Node 20+):
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000) to see the app.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+
+declare module 'shadcn-ui';

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "deep-space-tic-tac-toe",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "shadcn-ui": "^0.7.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^2.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^15.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-orbitron bg-black text-white min-h-screen flex flex-col items-center;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import Head from 'next/head';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+        <title>Deep Space Tic-Tac-Toe</title>
+      </Head>
+      <body>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,10 @@
+import TicTacToe from '../components/TicTacToe';
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center justify-center py-10 space-y-8">
+      <h1 className="text-4xl font-bold">Deep Space Tic-Tac-Toe</h1>
+      <TicTacToe />
+    </main>
+  );
+}

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useState } from 'react';
+
+type Player = 'X' | 'O';
+
+type SquareValue = Player | null;
+
+const winningCombos = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+];
+
+function calculateWinner(squares: SquareValue[]): Player | null {
+  for (const [a, b, c] of winningCombos) {
+    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+      return squares[a];
+    }
+  }
+  return null;
+}
+
+export default function TicTacToe() {
+  const [squares, setSquares] = useState<Array<SquareValue>>(Array(9).fill(null));
+  const [xIsNext, setXIsNext] = useState(true);
+  const [score, setScore] = useState({ X: 0, O: 0 });
+
+  const winner = calculateWinner(squares);
+  const currentPlayer: Player = xIsNext ? 'X' : 'O';
+
+  function handleClick(i: number) {
+    if (squares[i] || winner) return;
+    const newSquares = squares.slice();
+    newSquares[i] = currentPlayer;
+    setSquares(newSquares);
+    const newWinner = calculateWinner(newSquares);
+    if (newWinner) {
+      setScore({ ...score, [newWinner]: score[newWinner] + 1 });
+    }
+    setXIsNext(!xIsNext);
+  }
+
+  function renderSquare(i: number) {
+    return (
+      <button
+        key={i}
+        onClick={() => handleClick(i)}
+        className="w-16 h-16 md:w-20 md:h-20 border border-gray-500 flex items-center justify-center text-2xl md:text-3xl"
+      >
+        {squares[i]}
+      </button>
+    );
+  }
+
+  function reset() {
+    setSquares(Array(9).fill(null));
+    setXIsNext(true);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-4 text-xl">
+        <div>Player X: {score.X}</div>
+        <div>Player O: {score.O}</div>
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        {squares.map((_, i) => renderSquare(i))}
+      </div>
+      <div className="space-y-2">
+        {winner && <div className="text-lg">Winner: {winner}</div>}
+        <button onClick={reset} className="px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded">
+          Reset Game
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import * as React from 'react';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-purple-600 text-white hover:bg-purple-700',
+        outline: 'border border-purple-600 text-purple-600 hover:bg-purple-600/10',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 px-3',
+        lg: 'h-11 px-8',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        orbitron: ['Orbitron', 'sans-serif']
+      }
+    }
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js 15 + React 19 project
- configure Tailwind and basic shadcn/ui setup
- add Orbitron font and global styles
- implement Tic-Tac-Toe game with scoreboard

## Testing
- `npx create-next-app@latest app ...` *(fails: 403 Forbidden)*

------
